### PR TITLE
chore: fix a few typos

### DIFF
--- a/CortexCube/chains/llm_math_chain.py
+++ b/CortexCube/chains/llm_math_chain.py
@@ -27,7 +27,7 @@ _PROMPT_TEMPLATE = """Translate a math problem into a expression that can be exe
 You MUST follow the following guidelines:
  - Do not use "where(...)" expressions in your code since it is not supported.
  - Do not use "fmax(...)" expression in your code since it is not supported. Use "max(...)" instead.
- - You MUST never introduce a new variable in any mathmatical expression. The mathematical expression MUST ONLY contain numbers and operations. For instance gazelle_max_speed * 0.12 is NEVER allowed and you must find the numerical value of the gazelle's max speed from the given context.
+ - You MUST never introduce a new variable in any mathematical expression. The mathematical expression MUST ONLY contain numbers and operations. For instance gazelle_max_speed * 0.12 is NEVER allowed and you must find the numerical value of the gazelle's max speed from the given context.
 
 Begin.
 

--- a/CortexCube/tools/snowflake_analyst_prompts.py
+++ b/CortexCube/tools/snowflake_analyst_prompts.py
@@ -1,4 +1,4 @@
-from CortexCube.cube.constants import END_OF_PLAN, JOINNER_FINISH,JOINNER_REPLAN
+from CortexCube.cube.constants import END_OF_PLAN, JOINNER_FINISH, JOINNER_REPLAN
 
 
 PLANNER_PROMPT = (
@@ -19,7 +19,7 @@ PLANNER_PROMPT = (
     "Question: What is the Revenue of the competitors mentioned in Snowflake's annual report?\n"
     "Thought: I first nneed to identify which companies are considered Snowflake's competitors.\n"
     '1. cortexsearch("Snowflake competitors mentioned in the annual report")\n'
-    "Thought: Now that I know the copmetitors, I can look up their financials in my database, if they're in the S&P500.\n"
+    "Thought: Now that I know the competitors, I can look up their financials in my database, if they're in the S&P500.\n"
     '2. cortexanalyst("What is the Revenue of Amazon, Microsoft, and Google?")\n'
     "Thought: I can answer the question now.\n"
     f"3. join(){END_OF_PLAN}\n")

--- a/CubeQuickstart.ipynb
+++ b/CubeQuickstart.ipynb
@@ -16,7 +16,7 @@
     "CortexCube can be configured to work with 3 types of tools:\n",
     "- Cortex Search Tool: For unstructured data analysis, which requires a standard RAG access pattern.\n",
     "- Cortex Analyst Tool: For supporting structured data analysis, which requires a Text2SQL access pattern.\n",
-    "- Python Tool: For supporting custom user operations (using 3rd Party API's), which requires calling arbitray python.\n",
+    "- Python Tool: For supporting custom user operations (using 3rd Party API's), which requires calling arbitrary python.\n",
     "\n",
     "This notebook walks through how to configure and run a system with all 3 types of tools. The demo is designed to illustrate how the agent can answer questions that require a divserse combination of tools (RAG,Text2SQL, Python, or a combination).\n",
     "\n",
@@ -41,7 +41,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Authenticate with Snowpark + set token as enviornment variable for use by the agents."
+    "Authenticate with Snowpark + set token as environment variable for use by the agents."
    ]
   },
   {
@@ -75,19 +75,19 @@
     }
    ],
    "source": [
-    "from CortexCube import CortexCube, CortexSearchTool,CortexAnalystTool,PythonTool\n",
+    "from CortexCube import CortexCube, CortexSearchTool, CortexAnalystTool, PythonTool\n",
     "from snowflake.snowpark import Session\n",
     "import os, time\n",
     "\n",
     "connection_parameters = {\n",
-    "    \n",
-    "    \"account\": os.getenv('SNOWFLAKE_ACCOUNT'),\n",
-    "    \"user\": os.getenv('SNOWFLAKE_USER'),\n",
-    "    \"password\": os.getenv('SNOWFLAKE_PASSWORD'),\n",
-    "    \"role\": os.getenv('SNOWFLAKE_ROLE'),\n",
-    "    \"warehouse\": os.getenv('SNOWFLAKE_WAREHOUSE'),\n",
-    "    \"database\": os.getenv('SNOWFLAKE_DATABASE'),\n",
-    "    \"schema\": os.getenv('SNOWFLAKE_SCHEMA')}  \n",
+    "    \"account\": os.getenv(\"SNOWFLAKE_ACCOUNT\"),\n",
+    "    \"user\": os.getenv(\"SNOWFLAKE_USER\"),\n",
+    "    \"password\": os.getenv(\"SNOWFLAKE_PASSWORD\"),\n",
+    "    \"role\": os.getenv(\"SNOWFLAKE_ROLE\"),\n",
+    "    \"warehouse\": os.getenv(\"SNOWFLAKE_WAREHOUSE\"),\n",
+    "    \"database\": os.getenv(\"SNOWFLAKE_DATABASE\"),\n",
+    "    \"schema\": os.getenv(\"SNOWFLAKE_SCHEMA\"),\n",
+    "}\n",
     "\n",
     "snowpark = Session.builder.configs(connection_parameters).create()\n",
     "\n",
@@ -116,19 +116,19 @@
    "outputs": [],
    "source": [
     "search_config = {\n",
-    "    \"service_name\":\"SEC_SEARCH_SERVICE\",\n",
-    "    \"service_topic\":\"Snowflake's business,product offerings,and performance\",\n",
+    "    \"service_name\": \"SEC_SEARCH_SERVICE\",\n",
+    "    \"service_topic\": \"Snowflake's business,product offerings,and performance\",\n",
     "    \"data_description\": \"Snowflake annual reports\",\n",
-    "    \"retrieval_columns\":[\"CHUNK\"],\n",
-    "    \"snowpark_connection\": snowpark\n",
+    "    \"retrieval_columns\": [\"CHUNK\"],\n",
+    "    \"snowpark_connection\": snowpark,\n",
     "}\n",
     "\n",
     "analyst_config = {\n",
-    "    \"semantic_model\":\"sp500_semantic_model.yaml\",\n",
-    "    \"stage\":\"SEMANTICS\",\n",
-    "    \"service_topic\":\"S&P500 company and stock metrics\",\n",
+    "    \"semantic_model\": \"sp500_semantic_model.yaml\",\n",
+    "    \"stage\": \"SEMANTICS\",\n",
+    "    \"service_topic\": \"S&P500 company and stock metrics\",\n",
     "    \"data_description\": \"a table with stock and financial metrics about S&P500 companies \",\n",
-    "    \"snowpark_connection\": snowpark\n",
+    "    \"snowpark_connection\": snowpark,\n",
     "}"
    ]
   },
@@ -154,27 +154,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import requests,json\n",
+    "import requests, json\n",
+    "\n",
     "\n",
     "class NewsTool:\n",
     "\n",
-    "    def __init__(self,token,limit) -> None:\n",
+    "    def __init__(self, token, limit) -> None:\n",
     "\n",
     "        self.api_token = token\n",
-    "        self.limit = limit  \n",
-    "    \n",
-    "    def search(self,news_query:str)->str: \n",
+    "        self.limit = limit\n",
+    "\n",
+    "    def search(self, news_query: str) -> str:\n",
     "\n",
     "        print(\"Running News Search tool....\")\n",
     "        news_request = f\"\"\"https://api.thenewsapi.com/v1/news/all?api_token={self.api_token}&search={news_query}&language=en&limit={self.limit}\"\"\"\n",
-    "        response = requests.get(news_request)            \n",
-    "        json_response = json.loads(response.content)['data']\n",
+    "        response = requests.get(news_request)\n",
+    "        json_response = json.loads(response.content)[\"data\"]\n",
     "\n",
     "        return str(json_response)\n",
     "\n",
+    "\n",
     "tool_desc = \"searches for relevant news based on user query\"\n",
     "output = \"relevant articles\"\n",
-    "news_api_func= NewsTool(token=os.getenv(\"NEWS_API_TOKEN\"),limit=3).search\n"
+    "news_api_func = NewsTool(token=os.getenv(\"NEWS_API_TOKEN\"), limit=3).search"
    ]
   },
   {
@@ -207,11 +209,13 @@
     }
    ],
    "source": [
-    "annual_reports = CortexSearchTool(config = search_config,k=5)\n",
-    "sp500 = CortexAnalystTool(config = analyst_config)\n",
-    "news_search = PythonTool(python_func=news_api_func,tool_description=tool_desc,output_description=output)\n",
+    "annual_reports = CortexSearchTool(config=search_config, k=5)\n",
+    "sp500 = CortexAnalystTool(config=analyst_config)\n",
+    "news_search = PythonTool(\n",
+    "    python_func=news_api_func, tool_description=tool_desc, output_description=output\n",
+    ")\n",
     "\n",
-    "snowflake_tools = [annual_reports,sp500,news_search]\n",
+    "snowflake_tools = [annual_reports, sp500, news_search]\n",
     "agent = CortexCube(tools=snowflake_tools)"
    ]
   },
@@ -257,7 +261,7 @@
    "source": [
     "question = \"What is the market cap of Apple? \"\n",
     "agent_answer = await agent.acall(question)\n",
-    "print(agent_answer['output'])"
+    "print(agent_answer[\"output\"])"
    ]
   },
   {
@@ -278,7 +282,7 @@
    "source": [
     "question = \"Which company has the bigger EBITDA, Apple or MSFT? \"\n",
     "agent_answer = await agent.acall(question)\n",
-    "print(agent_answer['output'])\n"
+    "print(agent_answer[\"output\"])"
    ]
   },
   {
@@ -305,7 +309,7 @@
    "source": [
     "question = \"How many customers does Snowflake have?\"\n",
     "agent_answer = await agent.acall(question)\n",
-    "print(agent_answer['output'])\n"
+    "print(agent_answer[\"output\"])"
    ]
   },
   {
@@ -331,7 +335,7 @@
    "source": [
     "question = \"Give me recent news about Azure's AI investments\"\n",
     "agent_answer = await agent.acall(question)\n",
-    "print(agent_answer['output'])"
+    "print(agent_answer[\"output\"])"
    ]
   },
   {
@@ -359,7 +363,7 @@
    "source": [
     "question = \"What are the top 5 companies in the S&P by EBITDA? Are any of them mentioned as competitors in Snowflake's annual report?\"\n",
     "agent_answer = await agent.acall(question)\n",
-    "print(agent_answer['output'])"
+    "print(agent_answer[\"output\"])"
    ]
   },
   {
@@ -398,15 +402,16 @@
    "source": [
     "import os\n",
     "import streamlit as st\n",
+    "\n",
     "connection_parameters = {\n",
-    "    \n",
-    "    \"account\": os.getenv('SNOWFLAKE_ACCOUNT'),\n",
-    "    \"user\": os.getenv('SNOWFLAKE_USER'),\n",
-    "    \"password\": os.getenv('SNOWFLAKE_PASSWORD'),\n",
-    "    \"role\": os.getenv('SNOWFLAKE_ROLE'),\n",
-    "    \"warehouse\": os.getenv('SNOWFLAKE_WAREHOUSE'),\n",
-    "    \"database\": os.getenv('SNOWFLAKE_DATABASE'),\n",
-    "    \"schema\": os.getenv('SNOWFLAKE_SCHEMA')}  \n",
+    "    \"account\": os.getenv(\"SNOWFLAKE_ACCOUNT\"),\n",
+    "    \"user\": os.getenv(\"SNOWFLAKE_USER\"),\n",
+    "    \"password\": os.getenv(\"SNOWFLAKE_PASSWORD\"),\n",
+    "    \"role\": os.getenv(\"SNOWFLAKE_ROLE\"),\n",
+    "    \"warehouse\": os.getenv(\"SNOWFLAKE_WAREHOUSE\"),\n",
+    "    \"database\": os.getenv(\"SNOWFLAKE_DATABASE\"),\n",
+    "    \"schema\": os.getenv(\"SNOWFLAKE_SCHEMA\"),\n",
+    "}\n",
     "\n",
     "st.write(connection_parameters)\n",
     "\n",
@@ -432,6 +437,7 @@
    ],
    "source": [
     "from dotenv import load_dotenv\n",
+    "\n",
     "load_dotenv()\n",
     "os.getenv(\"SNOWFLAKE_ACCOUNT\")"
    ]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cortex Cube is a multi-agent framework that offers native support for Snowflake 
 CortexCube can be configured to work with 3 types of tools:
 - **Cortex Search Tool**: For unstructured data analysis, which requires a standard RAG access pattern.
 - **Cortex Analyst Tool**: For supporting structured data analysis, which requires a Text2SQL access pattern.
-- **Python Tool**: For supporting custom user operations (using 3rd Party API's), which requires calling arbitray python.
+- **Python Tool**: For supporting custom user operations (using 3rd Party API's), which requires calling arbitrary python.
 
 This notebook walks through how to configure and run a system with all 3 types of tools. The demo is designed to illustrate how the agent can answer questions that require a divserse combination of tools (RAG,Text2SQL, Python, or a combination).
 
@@ -16,7 +16,7 @@ Note that Cortex Cube does not configure the underlying Cortex Search or Cortex 
 >**Authentication for Mac Users**
 
 > Mac users have reported SSL Certificate authentication issues for Snowflake's Cortex REST API, which impacts Cortex Cube. We've found that
-python enviornments on Mac don't always have access to the requisite certificates to succesfully hit the REST endpoints.
+python environments on Mac don't always have access to the requisite certificates to successfully hit the REST endpoints.
 To resolve this, cd into your Python directory and run ./Install\ Certificates.command. Alternatively, using  Finder lookup the "Install  
 Certificates.command" and double click to run the file in your relevant Python directory. (If multiple results show up on Finder, make sure 
 to run the one in the appropriate path for your application).]

--- a/cube_demo_app/cube_demo_app.py
+++ b/cube_demo_app/cube_demo_app.py
@@ -1,31 +1,35 @@
+from dotenv import load_dotenv
 import snowflake
 from snowflake.snowpark import Session
 
 import streamlit as st
-import contextlib, io,json
+import contextlib
+import io
+import json
 import asyncio
 
-import os,uuid
-import sys, requests
+import os
+import uuid
+import sys
+import requests
 
-from CortexCube import CortexCube,CortexAnalystTool,CortexSearchTool,PythonTool
+from CortexCube import CortexCube, CortexAnalystTool, CortexSearchTool, PythonTool
 import warnings
-warnings.filterwarnings('ignore') 
+warnings.filterwarnings('ignore')
 
-from dotenv import load_dotenv
 load_dotenv("../.env")
 
 st.set_page_config(page_title="Snowflake Cortex Cube")
 
 connection_parameters = {
-    
+
     "account": os.getenv('SNOWFLAKE_ACCOUNT'),
     "user": os.getenv('SNOWFLAKE_USER'),
     "password": os.getenv('SNOWFLAKE_PASSWORD'),
     "role": os.getenv('SNOWFLAKE_ROLE'),
     "warehouse": os.getenv('SNOWFLAKE_WAREHOUSE'),
     "database": os.getenv('SNOWFLAKE_DATABASE'),
-    "schema": os.getenv('SNOWFLAKE_SCHEMA')}  
+    "schema": os.getenv('SNOWFLAKE_SCHEMA')}
 
 os.environ["SNOWFLAKE_ACCOUNT"] = connection_parameters["account"]
 os.environ["NEWS_API_TOKEN"] = os.getenv("NEWS_API_TOKEN")
@@ -33,25 +37,27 @@ os.environ["NEWS_API_TOKEN"] = os.getenv("NEWS_API_TOKEN")
 snowpark = Session.builder.configs(connection_parameters).create()
 os.environ["SNOWFLAKE_API_KEY"] = snowpark.connection.rest.token
 
+
 class NewsTool:
 
-    def __init__(self,token,limit) -> None:
+    def __init__(self, token, limit) -> None:
 
         self.api_token = token
-        self.limit = limit  
-    
-    def search(self,news_query:str)->str: 
+        self.limit = limit
+
+    def search(self, news_query: str) -> str:
 
         print("Running News Search tool....")
         news_request = f"""https://api.thenewsapi.com/v1/news/all?api_token={self.api_token}&search={news_query}&language=en&limit={self.limit}"""
-        response = requests.get(news_request)            
+        response = requests.get(news_request)
         json_response = json.loads(response.content)['data']
 
         return str(json_response)
 
+
 tool_desc = "searches for relevant news based on user query"
 output = "relevant articles"
-news_api_func= NewsTool(token=os.getenv("NEWS_API_TOKEN"),limit=3).search
+news_api_func = NewsTool(token=os.getenv("NEWS_API_TOKEN"), limit=3).search
 
 
 if 'prompt_history' not in st.session_state:
@@ -59,44 +65,50 @@ if 'prompt_history' not in st.session_state:
 
 if 'CONN' not in st.session_state or st.session_state.CONN is None:
 
-    
-    
-    st.session_state.CONN = snowflake.connector.connect(**connection_parameters)
-    st.session_state.snowpark = Session.builder.configs(connection_parameters).create()
-    
-    
+    st.session_state.CONN = snowflake.connector.connect(
+        **connection_parameters)
+    st.session_state.snowpark = Session.builder.configs(
+        connection_parameters).create()
+
     search_config = {
-    "service_name":"SEC_SEARCH_SERVICE",
-    "service_topic":"Snowflake's business,product offerings,and performance",
-    "data_description": "Snowflake annual reports",
-    "retrieval_columns":["CHUNK"],
-    "snowpark_connection": snowpark
+        "service_name": "SEC_SEARCH_SERVICE",
+        "service_topic": "Snowflake's business,product offerings,and performance",
+        "data_description": "Snowflake annual reports",
+        "retrieval_columns": ["CHUNK"],
+        "snowpark_connection": snowpark
     }
 
     analyst_config = {
-        "semantic_model":"sp500_semantic_model.yaml",
-        "stage":"SEMANTICS",
-        "service_topic":"S&P500 company and stock metrics",
+        "semantic_model": "sp500_semantic_model.yaml",
+        "stage": "SEMANTICS",
+        "service_topic": "S&P500 company and stock metrics",
         "data_description": "a table with stock and financial metrics about S&P500 companies ",
         "snowpark_connection": snowpark
     }
-    
+
     # Tools Config
-    st.session_state.annual_reports = CortexSearchTool(config = search_config,k=5)
-    st.session_state.sp500 = CortexAnalystTool(config = analyst_config)
-    st.session_state.news_search = PythonTool(python_func=news_api_func,tool_description=tool_desc,output_description=output)
-    st.session_state.snowflake_tools = [st.session_state.annual_reports,st.session_state.sp500,st.session_state.news_search]
+    st.session_state.annual_reports = CortexSearchTool(
+        config=search_config, k=5)
+    st.session_state.sp500 = CortexAnalystTool(config=analyst_config)
+    st.session_state.news_search = PythonTool(
+        python_func=news_api_func, tool_description=tool_desc, output_description=output)
+    st.session_state.snowflake_tools = [
+        st.session_state.annual_reports, st.session_state.sp500, st.session_state.news_search]
 
 
 if 'analyst' not in st.session_state:
-    
-    st.session_state.analyst = CortexCube(tools=st.session_state.snowflake_tools)
 
-def create_prompt(prompt_key:str):
+    st.session_state.analyst = CortexCube(
+        tools=st.session_state.snowflake_tools)
+
+
+def create_prompt(prompt_key: str):
 
     if prompt_key in st.session_state:
-        prompt_record = dict(prompt =st.session_state[prompt_key], response='waiting' )
+        prompt_record = dict(
+            prompt=st.session_state[prompt_key], response='waiting')
         st.session_state['prompt_history'][str(uuid.uuid4())] = prompt_record
+
 
 class StreamlitOutputRedirector:
     def __init__(self, placeholder):
@@ -113,7 +125,10 @@ class StreamlitOutputRedirector:
     def get_output(self):
         return self.buffer.getvalue()
 
+
 source_list = []
+
+
 @contextlib.contextmanager
 def redirect_stdout_to_streamlit(placeholder):
     redirector = StreamlitOutputRedirector(placeholder)
@@ -124,6 +139,7 @@ def redirect_stdout_to_streamlit(placeholder):
     finally:
         sys.stdout = old_stdout
 
+
 def process_message(prompt_id: str) -> None:
     """Processes a message and adds the response to the chat."""
     prompt = st.session_state['prompt_history'][prompt_id].get('prompt')
@@ -132,8 +148,9 @@ def process_message(prompt_id: str) -> None:
 
     with redirect_stdout_to_streamlit(output_container) as redirector:
         # Call the analyst method and capture the output
-        response = asyncio.run(st.session_state.analyst.acall(prompt))['output']
-        
+        response = asyncio.run(
+            st.session_state.analyst.acall(prompt))['output']
+
         # Extract tool information from the output
         lines = redirector.get_output().split('\n')
         sources = []
@@ -142,8 +159,8 @@ def process_message(prompt_id: str) -> None:
             if tool_name is not None:
                 sources.append(tool_name)
                 # Display tool information
-                #tool_info_container.write(f"Using tool: {tool_name}")
-                
+                # tool_info_container.write(f"Using tool: {tool_name}")
+
     # Construct the final response with tool information
     cleaned_sources = [source for source in set(sources) if source != '']
     source_output = ', '.join(list(set(cleaned_sources)))
@@ -159,11 +176,13 @@ def process_message(prompt_id: str) -> None:
 #         selected_tool_name = words[0]  # Assuming the tool name is the first word
 #         if selected_tool_name.lower() != "finish":
 #             return selected_tool_name.strip()
-        
+
+
 def extract_tool_name(statement):
     start = statement.find('Running') + len('Running') + 1
     end = statement.find('tool')
     return statement[start:end].strip()
+
 
 # Add custom CSS to resize the logo
 st.markdown("""
@@ -181,32 +200,33 @@ st.markdown("""
 """, unsafe_allow_html=True)
 
 st.logo("SIT_logo_white.png")
-#st.title("Cortex Multi Agent Analyst")
+# st.title("Cortex Multi Agent Analyst")
 st.markdown(
     "<h1>🧠 Snowflake Cortex<sup style='font-size:.8em;'>3</sup></h1>",
     unsafe_allow_html=True,
 )
-st.caption("A Multi-Agent System with access to Cortex, Cortex Search, Cortex Analyst, and more.")
+st.caption(
+    "A Multi-Agent System with access to Cortex, Cortex Search, Cortex Analyst, and more.")
 
 # for id in st.session_state.prompt_history:
-    
+
 #     current_prompt = st.session_state.prompt_history.get(id)
-    
+
 #     with st.chat_message('user'):
 #         st.write(current_prompt.get('prompt'))
 #     with st.chat_message('assistant'):
-      
+
 #         if current_prompt.get('response') == 'waiting':
-            
-#             with st.status("Awaiting Reponse", expanded=True):
-        
+
+#             with st.status("Awaiting Response", expanded=True):
+
 #                 st.write_stream(process_message(prompt_id=id))
 #         else:
-            # st.write(st.session_state['prompt_history'][id]['response'],unsafe_allow_html=True)
+# st.write(st.session_state['prompt_history'][id]['response'],unsafe_allow_html=True)
 
 for id in st.session_state.prompt_history:
     current_prompt = st.session_state.prompt_history.get(id)
-    
+
     with st.chat_message('user'):
         st.write(current_prompt.get('prompt'))
     with st.chat_message('assistant'):
@@ -214,12 +234,9 @@ for id in st.session_state.prompt_history:
             with st.status("Awaiting Response", expanded=True):
                 st.write_stream(process_message(prompt_id=id))
         else:
-            st.write(st.session_state['prompt_history'][id]['response'], unsafe_allow_html=True)
- 
-        
-
-st.chat_input("Ask Anything", on_submit=create_prompt,key='chat_input', args=['chat_input'])
+            st.write(st.session_state['prompt_history']
+                     [id]['response'], unsafe_allow_html=True)
 
 
-
-
+st.chat_input("Ask Anything", on_submit=create_prompt,
+              key='chat_input', args=['chat_input'])


### PR DESCRIPTION
This PR fixes a couple of outstanding typos. 

There are a few still showing up, but these should be okay.

I think these are intentional (Where aapply is likely short for async apply?):
```
CortexCube/chains/llm_chain.py:244: aapply ==> apply
CortexCube/chains/llm_chain.py:382: aapply ==> apply
```

These notebook cell outputs
```
CubeQuickstart.ipynb:205: succesfully ==> successfully
CubeQuickstart.ipynb:206: succesfully ==> successfully
CubeQuickstart.ipynb:207: succesfully ==> successfully
```
will likely get cleared out if we fix these:

```
CortexCube/tools/snowflake_tools.py:23: succesfully ==> successfully
CortexCube/tools/snowflake_tools.py:87: succesfully ==> successfully
CortexCube/tools/snowflake_tools.py:178: succesfully ==> successfully
```

