### PR TITLE
refactor: rename snowpark_connection arg to snowflake_connection

### DIFF
--- a/CortexCube/tools/snowflake_tools.py
+++ b/CortexCube/tools/snowflake_tools.py
@@ -38,7 +38,7 @@ class CortexSearchTool(Tool):
         service_topic,
         data_description,
         retrieval_columns,
-        snowpark_connection,
+        snowflake_connection,
         auto_filter=False,
         k=5,
     ):
@@ -49,7 +49,7 @@ class CortexSearchTool(Tool):
         service_topic (str): description of content indexed by Cortex Search.
         data_description (str): description of the source data that has been indexed.
         retrieval_columns (list): list of columns to include in Cortex Search results.
-        snowpark_connection (object): snowpark connection object
+        snowflake_connection (object): snowpark connection object
         auto_filter (bool): automatically generate filter based on user's query or not.
         k: number of records to include in results
         """
@@ -64,7 +64,7 @@ class CortexSearchTool(Tool):
             name=tool_name, description=tool_description, func=self.asearch
         )
         self.auto_filter = auto_filter
-        self.session = snowpark_connection
+        self.session = snowflake_connection
         if self.auto_filter:
             self.filter_generator = SmartSearch()
             lm = dspy.Snowflake(session=self.session, model="mixtral-8x7b")
@@ -299,7 +299,7 @@ class CortexAnalystTool(Tool):
         stage,
         service_topic,
         data_description,
-        snowpark_connection,
+        snowflake_connection,
     ):
         """Parameters
 
@@ -308,7 +308,7 @@ class CortexAnalystTool(Tool):
         stage (str): name of stage containing semantic model yaml.
         service_topic (str): topic of the data in the tables (i.e S&P500 company financials).
         data_description (str): description of the source data that has been indexed (i.e a table with stock and financial metrics about S&P500 companies).
-        snowpark_connection (object): snowpark connection object
+        snowflake_connection (object): snowpark connection object
         """
 
         tname = semantic_model.replace(".yaml", "") + "_" + "cortexanalyst"
@@ -319,7 +319,7 @@ class CortexAnalystTool(Tool):
         )
 
         super().__init__(name=tname, func=self.asearch, description=tool_description)
-        self.CONN = snowpark_connection
+        self.CONN = snowflake_connection
         self.FILE = semantic_model
         self.STAGE = stage
 

--- a/CubeQuickstart.ipynb
+++ b/CubeQuickstart.ipynb
@@ -110,7 +110,7 @@
     "    \"service_topic\": \"Snowflake's business,product offerings,and performance\",\n",
     "    \"data_description\": \"Snowflake annual reports\",\n",
     "    \"retrieval_columns\": [\"CHUNK\"],\n",
-    "    \"snowpark_connection\": snowpark,\n",
+    "    \"snowflake_connection\": snowpark,\n",
     "}\n",
     "\n",
     "analyst_config = {\n",
@@ -118,7 +118,7 @@
     "    \"stage\": \"ANALYST\",\n",
     "    \"service_topic\": \"S&P500 company and stock metrics\",\n",
     "    \"data_description\": \"a table with stock and financial metrics about S&P500 companies \",\n",
-    "    \"snowpark_connection\": snowpark,\n",
+    "    \"snowflake_connection\": snowpark,\n",
     "}"
    ]
   },

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Cortex Cube 
+# Cortex Cube
 
-Cortex Cube is a multi-agent framework that offers native support for Snowflake tools. Instead of requiring users or developers to choose between RAG with Cortex Search or Text2SQL with Cortex Analyst, let the Cube orchestrate the user requests to the appropriate tool. 
+Cortex Cube is a multi-agent framework that offers native support for Snowflake tools. Instead of requiring users or developers to choose between RAG with Cortex Search or Text2SQL with Cortex Analyst, let the Cube orchestrate the user requests to the appropriate tool.
 
 CortexCube can be configured to work with 3 types of tools:
 - **Cortex Search Tool**: For unstructured data analysis, which requires a standard RAG access pattern.
 - **Cortex Analyst Tool**: For supporting structured data analysis, which requires a Text2SQL access pattern.
 - **Python Tool**: For supporting custom user operations (i.e. sending API requests to third party services), which requires calling arbitrary python.
 
-Users have the flexibility to create multiple Cortex Search and Cortex Analyst tools for use with Cortex Cube. For a walkthrough of how to configure and run a system with all 3 types of tools, see the quickstart notebook. 
+Users have the flexibility to create multiple Cortex Search and Cortex Analyst tools for use with Cortex Cube. For a walkthrough of how to configure and run a system with all 3 types of tools, see the quickstart notebook.
 
-# Getting Started 
+# Getting Started
 
-## Installation 
+## Installation
 In a new virtual enviornment with Python 3.10 or 3.11, install the latest version of Cortex Cube.
 ```python
 pip install cortex-cube@git+https://github.com/sfc-gh-alherrera/cortex-cube.git
@@ -20,7 +20,7 @@ pip install cortex-cube@git+https://github.com/sfc-gh-alherrera/cortex-cube.git
 **Note For Mac Users**: Mac users have reported SSL Certificate issues when using the Cortex REST API. This is related to python virtual enviornments not having access to local certificates. One potential solution to avoid SSL Certificate issues is to use Finder to locate the "Install Certificates.command" file in your relevant python directory and run that file before initializing Cortex Cube. See [this thread](https://github.com/python/cpython/issues/87570#issuecomment-1093904961) for more info.
 
 ## Tool Requirements
-Cortex Cube requires the underlying Cortex Search, Cortex Analyst, or Python tools to be configured by the user. 
+Cortex Cube requires the underlying Cortex Search, Cortex Analyst, or Python tools to be configured by the user.
 
 To follow the Quickstart notebook in this repo, you can generate the Cortex Search and Cortex Analyst demo services as follows:
 ```python
@@ -28,14 +28,14 @@ from CortexCube.tools.utils import generate_demo_services
 from snowflake.snowpark import Session
 
 connection_parameters = {
-    
+
     "account": os.getenv('SNOWFLAKE_ACCOUNT'),
     "user": os.getenv('SNOWFLAKE_USER'),
     "password": os.getenv('SNOWFLAKE_PASSWORD'),
     "role": os.getenv('SNOWFLAKE_ROLE'),
     "warehouse": os.getenv('SNOWFLAKE_WAREHOUSE'),
     "database": os.getenv('SNOWFLAKE_DATABASE'),
-    "schema": os.getenv('SNOWFLAKE_SCHEMA')}  
+    "schema": os.getenv('SNOWFLAKE_SCHEMA')}
 
 session = Session.builder.configs(connection_parameters).create()
 
@@ -58,7 +58,7 @@ search_config = {
     "service_topic":"Snowflake's business,product offerings,and performance",
     "data_description": "Snowflake annual reports",
     "retrieval_columns":["CHUNK"],
-    "snowpark_connection": session
+    "snowflake_connection": session
 }
 
 annual_reports = CortexSearchTool(**search_config)
@@ -71,7 +71,7 @@ analyst_config = {
     "stage":"SEMANTICS",
     "service_topic":"S&P500 company and stock metrics",
     "data_description": "a table with stock and financial metrics about S&P500 companies ",
-    "snowpark_connection": session
+    "snowflake_connection": session
 }
 
 sp500 = CortexAnalystTool(**analyst_config)
@@ -115,7 +115,7 @@ print(answer)
 - Cortex Cube takes an authenticated snowpark connection. Just create your session object with your standard [connection parameters](https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/latest/snowpark/api/snowflake.snowpark.Session)
 
 #### If I have multiple Cortex Search Services, can I use multiple Cortex Search tools with Cortex Cube?
-- Yes, Cortex Cube supports the use of multiple tools of the same type. 
+- Yes, Cortex Cube supports the use of multiple tools of the same type.
 ```python
 search_one = CortexSearchTool(**search_one_config)
 search_two = CortexSearchTool(**search_two_config)
@@ -136,7 +136,3 @@ tool_result = await my_cortex_search_tool("This is a sample cortex search questi
 
 # Bug Reports, Feedback, or Other Questions
 - You can add issues to the github or email Alejandro Herrera (alejandro.herrera@snowflake.com)
-
-
-
-

--- a/cube_demo_app/cube_demo_app.py
+++ b/cube_demo_app/cube_demo_app.py
@@ -64,7 +64,7 @@ if "snowpark" not in st.session_state or st.session_state.snowpark is None:
         "service_topic": "Snowflake's business,product offerings,and performance",
         "data_description": "Snowflake annual reports",
         "retrieval_columns": ["CHUNK"],
-        "snowpark_connection": st.session_state.snowpark,
+        "snowflake_connection": st.session_state.snowpark,
     }
 
     analyst_config = {
@@ -72,7 +72,7 @@ if "snowpark" not in st.session_state or st.session_state.snowpark is None:
         "stage": "ANALYST",
         "service_topic": "S&P500 company and stock metrics",
         "data_description": "a table with stock and financial metrics about S&P500 companies ",
-        "snowpark_connection": st.session_state.snowpark,
+        "snowflake_connection": st.session_state.snowpark,
     }
 
     # Tools Config

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -27,7 +27,7 @@ def test_search_tool(session, question, answer):
         "service_topic": "Snowflake's business,product offerings,and performance",
         "data_description": "Snowflake annual reports",
         "retrieval_columns": ["CHUNK"],
-        "snowpark_connection": session,
+        "snowflake_connection": session,
     }
     annual_reports = CortexSearchTool(**search_config)
     response = asyncio.run(annual_reports(question))
@@ -56,7 +56,7 @@ def test_analyst_tool(session, question, answer):
         "stage": "ANALYST",
         "service_topic": "S&P500 company and stock metrics",
         "data_description": "a table with stock and financial metrics about S&P500 companies ",
-        "snowpark_connection": session,
+        "snowflake_connection": session,
     }
     sp500 = CortexAnalystTool(**analyst_config)
     response = asyncio.run(sp500(question))
@@ -101,14 +101,14 @@ def test_cube_agent(session, question, answer_contains):
         "service_topic": "Snowflake's business,product offerings,and performance",
         "data_description": "Snowflake annual reports",
         "retrieval_columns": ["CHUNK"],
-        "snowpark_connection": session,
+        "snowflake_connection": session,
     }
     analyst_config = {
         "semantic_model": "sp500_semantic_model.yaml",
         "stage": "ANALYST",
         "service_topic": "S&P500 company and stock metrics",
         "data_description": "a table with stock and financial metrics about S&P500 companies ",
-        "snowpark_connection": session,
+        "snowflake_connection": session,
     }
 
     def get_news(_) -> dict:


### PR DESCRIPTION
This will be part 1 of a larger refactor, we will need to adjust the typehints here so that users know it will take either a Snowpark Session or a Snowflake Python Connection and support either/or in the code.

This will be similar to what's being done with the `EndpointBuilder` class currently.