### PR TITLE
fix: ensure analyst semantic file overwrites uncompressed

### DIFF
--- a/agent_gateway/tools/utils.py
+++ b/agent_gateway/tools/utils.py
@@ -179,6 +179,8 @@ def generate_demo_services(session: Session):
     session.file.put_stream(
         pkg_resources.resource_stream(__name__, "data/sp500_semantic_model.yaml"),
         "CUBE_TESTING.PUBLIC.ANALYST/sp500_semantic_model.yaml",
+        auto_compress=False,
+        overwrite=True,
     )
     session.file.put_stream(
         pkg_resources.resource_stream(__name__, "data/sec_chunk_search.parquet"),


### PR DESCRIPTION
Closes #47 

While it's unlikely, we have seen a case where an existing file may have already been deployed using other means for the demo service, causing unexpected results when initializing the sample `AnalystTool`. This ensures that the file matches exactly what we have in the repository upon calling `generate_demo_services`. 