### PR TITLE
fix(tests): reset context on yielding test session and string list checking

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,4 +35,5 @@ class TestConf:
 def session():
     conf = TestConf()
     generate_demo_services(conf.session)
+    conf.session.use_schema("CUBE_TESTING.PUBLIC")
     yield conf.session

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -45,7 +45,7 @@ def test_search_tool(session, question, answer):
     annual_reports = CortexSearchTool(**search_config)
     response = asyncio.run(annual_reports(question))
 
-    assert answer in response[0].get("CHUNK")
+    assert answer in "".join([result.get("CHUNK") for result in response])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#53 introduced a small bug with the way we're setting up our test connection. This fixes that. 

The order of results from Cortex Search is not deterministic, which ensures that our test looks within the list of answers rather than the 0 index for assertion. 