### PR TITLE
feat: adding a naiive memory mechanism

### DIFF
--- a/agent_gateway/gateway/gateway.py
+++ b/agent_gateway/gateway/gateway.py
@@ -156,7 +156,7 @@ class Agent(Chain, extra="allow"):
             max_retries: Maximum number of replans to do. Defaults to 2.
             planner_llm: Name of Snowflake Cortex LLM to use for planning.
             agent_llm: Name of Snowflake Cortex LLM to use for planning.
-            memory: Boolean to turn on memory mechanism or not. Defaults to False.
+            memory: Boolean to turn on memory mechanism or not. Defaults to True.
             planner_example_prompt: Example prompt for planning. Defaults to SNOWFLAKE_PLANNER_PROMPT.
             planner_example_prompt_replan: Example prompt for replanning.
                 Assign this if you want to use different example prompt for replanning.

--- a/agent_gateway/gateway/gateway.py
+++ b/agent_gateway/gateway/gateway.py
@@ -191,6 +191,9 @@ class Agent(Chain, extra="allow"):
         self.planner_stream = planner_stream
         self.max_retries = max_retries
 
+        # basic memory
+        self.memory = []
+
         # callbacks
         self.planner_callback = None
         self.executor_callback = None
@@ -339,6 +342,10 @@ class Agent(Chain, extra="allow"):
         """
         result = []
         error = []
+
+        if len(self.memory) >= 1:
+            input = f"My previous question/answer was: {self.memory[0]}\n. If needed, use that context and this {input} to answer my question. Otherwise just give me an answer to: {input} "
+
         thread = threading.Thread(target=self.run_async, args=(input, result, error))
         thread.start()
         thread.join()
@@ -348,6 +355,10 @@ class Agent(Chain, extra="allow"):
 
         if not result:
             raise AgentGatewayError("Unable to retrieve response. Result is empty.")
+
+        max_memory = 3  # TODO consider exposing this to users
+        if len(self.memory) <= max_memory:
+            self.memory.append({"Question:": input, "Answer": result[0]})
 
         return result[0]
 


### PR DESCRIPTION
Exposes optional memory option to users in gateway definition. Defaults keeps up to 3 historical interactions in memory by default. 

this is a very naiive implementation and will like need to explore more advanced design patterns based on user feedback.
<img width="828" alt="Screenshot 2024-12-06 at 8 36 20 AM" src="https://github.com/user-attachments/assets/72cde2fa-070d-4dc2-aef2-03306bd7b151">


