### PR TITLE
perf: refactor if branching for logging check

### DIFF
--- a/agent_gateway/chains/chain.py
+++ b/agent_gateway/chains/chain.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_verbosity() -> bool:
-    return langchain.verbose
+    return langchain.globals.get_verbose()
 
 
 class Chain(Serializable, Runnable[Dict[str, Any], Dict[str, Any]], ABC):

--- a/agent_gateway/tools/logger.py
+++ b/agent_gateway/tools/logger.py
@@ -19,15 +19,8 @@ logging_enabled = os.getenv("LOGGING_ENABLED")
 if logging_enabled is None:
     LOGGING_ENABLED = True
 
-logging_level = os.getenv("LOGGING_LEVEL")
-if logging_level is None:
-    logging_level = logging.INFO
-elif logging_level == "INFO":
-    logging_level = logging.INFO
-elif logging_level == "DEBUG":
-    logging_level = logging.DEBUG
-else:
-    logging_level = logging.DEBUG
+logging_level = os.getenv("LOGGING_LEVEL", "INFO").upper()
+logging_level = getattr(logging, logging_level, logging.DEBUG)
 
 logging.basicConfig(level=logging.WARNING)
 


### PR DESCRIPTION
This simplifies the `if/elif/else` branching in the logging file and also removes
a langchain deprecation warning we've seen in our tests.