### PR TITLE
fix: import missing langchain module

### DIFF
--- a/agent_gateway/chains/chain.py
+++ b/agent_gateway/chains/chain.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import langchain
+import langchain.globals
 import yaml
 from langchain.callbacks.base import BaseCallbackManager
 from langchain.callbacks.manager import (


### PR DESCRIPTION
`langchain.globals` needs to be imported to use `langchain.globals.get_verbose()`. 