### PR TITLE
feat: switch over search and complete to use core API

### DIFF
--- a/Quickstart.ipynb
+++ b/Quickstart.ipynb
@@ -169,10 +169,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-13 17:24:15,091 - AgentGatewayLogger - INFO - Cortex Search Tool successfully initialized\n",
-      "2025-03-13 17:24:15,092 - AgentGatewayLogger - INFO - Cortex Analyst Tool successfully initialized\n",
-      "2025-03-13 17:24:15,093 - AgentGatewayLogger - INFO - Python Tool successfully initialized\n",
-      "2025-03-13 17:24:15,094 - AgentGatewayLogger - INFO - Cortex gateway successfully initialized\n"
+      "2025-03-19 14:22:14,554 - AgentGatewayLogger - INFO - Cortex Search Tool successfully initialized\n",
+      "2025-03-19 14:22:14,743 - AgentGatewayLogger - INFO - Cortex Analyst Tool successfully initialized\n",
+      "2025-03-19 14:22:14,748 - AgentGatewayLogger - INFO - Python Tool successfully initialized\n",
+      "2025-03-19 14:22:15,079 - AgentGatewayLogger - INFO - Cortex gateway successfully initialized\n"
      ]
     }
    ],
@@ -219,13 +219,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-13 17:24:22,280 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n"
+      "2025-03-19 14:22:24,065 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'output': 'The market cap of Apple is $3,019,131,060,224 or approximately $3.02 trillion.',\n",
+       "{'output': 'The market cap of Apple is $3,019,131,060,224, or approximately $3.02 trillion.',\n",
        " 'sources': [{'tool_type': 'cortex_analyst',\n",
        "   'tool_name': 'sp500_semantic_model_cortexanalyst',\n",
        "   'metadata': [{'Table': 'cube_testing.public.sp500'}]}]}"
@@ -249,8 +249,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-13 17:24:33,011 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n",
-      "2025-03-13 17:24:33,012 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n"
+      "2025-03-19 14:23:24,449 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n",
+      "2025-03-19 14:23:24,453 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n"
      ]
     },
     {
@@ -287,7 +287,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-13 17:24:49,879 - AgentGatewayLogger - INFO - running sec_search_service_cortexsearch task\n"
+      "2025-03-19 14:02:37,629 - AgentGatewayLogger - INFO - running sec_search_service_cortexsearch task\n"
      ]
     },
     {
@@ -313,14 +313,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-13 17:24:57,337 - AgentGatewayLogger - INFO - running html_crawl task\n"
+      "2025-03-19 14:23:36,187 - AgentGatewayLogger - INFO - running html_crawl task\n"
      ]
     },
     {
@@ -332,7 +332,7 @@
        "   'metadata': [None]}]}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -352,26 +352,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-13 17:25:14,329 - AgentGatewayLogger - INFO - running sec_search_service_cortexsearch task\n",
-      "2025-03-13 17:25:15,815 - AgentGatewayLogger - INFO - running summarize task\n",
-      "2025-03-13 17:25:17,261 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n",
-      "2025-03-13 17:25:21,736 - AgentGatewayLogger - ERROR - Your request is unclear. Consider rephrasing your request to one of the following suggestions: ['What is the market cap of Amazon.com, Inc., Microsoft Corporation, and Alphabet Inc.?', 'What is the market cap of the companies that own Amazon Web Services (AWS), Microsoft Azure, and Google Cloud Platform (GCP)?']\n",
-      "2025-03-13 17:25:30,092 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n",
-      "2025-03-13 17:25:33,332 - AgentGatewayLogger - ERROR - Unable to generate a valid SQL Query. The question is asking for the market cap of companies that own Amazon Web Services (AWS), but the semantic data model does not provide information about the ownership of AWS or any other subsidiary relationships. Therefore, it is unclear how to determine which companies own AWS based on the given schema.\n",
-      "2025-03-13 17:25:41,677 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n"
+      "2025-03-19 14:23:57,484 - AgentGatewayLogger - INFO - running sec_search_service_cortexsearch task\n",
+      "2025-03-19 14:23:58,467 - AgentGatewayLogger - INFO - running summarize task\n",
+      "2025-03-19 14:24:00,027 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n",
+      "2025-03-19 14:24:37,180 - AgentGatewayLogger - INFO - running sec_search_service_cortexsearch task\n",
+      "2025-03-19 14:24:38,132 - AgentGatewayLogger - INFO - running summarize task\n",
+      "2025-03-19 14:24:38,486 - AgentGatewayLogger - INFO - running sp500_semantic_model_cortexanalyst task\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'output': 'The market cap of Amazon.com, Inc. is $1,917,936,336,896, the market cap of Microsoft Corporation is $3,150,184,448,000, and the market cap of Alphabet Inc. is $2,164,350,779,392.',\n",
+       "{'output': 'The market cap of Microsoft is $3,150,184,448,000, the market cap of Alphabet Inc. (Google) is $2,164,350,779,392, and the market cap of Amazon.com, Inc. is $1,917,936,336,896.',\n",
        " 'sources': [{'tool_type': 'cortex_search',\n",
        "   'tool_name': 'sec_search_service_cortexsearch',\n",
        "   'metadata': [{'RELATIVE_PATH': '2023_10k_snowflake.pdf'},\n",
@@ -380,10 +379,13 @@
        "    {'RELATIVE_PATH': '2021_10k_snowflake.pdf'}]},\n",
        "  {'tool_type': 'cortex_analyst',\n",
        "   'tool_name': 'sp500_semantic_model_cortexanalyst',\n",
+       "   'metadata': [{'Table': None}]},\n",
+       "  {'tool_type': 'cortex_analyst',\n",
+       "   'tool_name': 'sp500_semantic_model_cortexanalyst',\n",
        "   'metadata': [{'Table': 'cube_testing.public.sp500'}]}]}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/agent_gateway/gateway/gateway.py
+++ b/agent_gateway/gateway/gateway.py
@@ -20,6 +20,11 @@ from collections.abc import Sequence
 from typing import Any, Dict, List, Mapping, Optional, Union, cast
 
 from snowflake.connector.connection import SnowflakeConnection
+from snowflake.core import Root
+from snowflake.core.cortex.inference_service import (
+    CompleteRequest,
+    CompleteRequestMessagesInner,
+)
 from snowflake.snowpark import Session
 
 from agent_gateway.gateway.constants import END_OF_PLAN, FUSION_REPLAN
@@ -32,10 +37,7 @@ from agent_gateway.tools.snowflake_prompts import (
     PLANNER_PROMPT as SNOWFLAKE_PLANNER_PROMPT,
 )
 from agent_gateway.tools.utils import (
-    CortexEndpointBuilder,
-    _determine_runtime,
     get_tag,
-    post_cortex_request,
 )
 
 
@@ -56,75 +58,25 @@ class CortexCompleteAgent:
             f"alter session set query_tag='{get_tag('CortexAnalystTool')}'"
         )
 
-    async def arun(self, prompt: str) -> str:
+    async def arun(self, messages: list[str, CompleteRequestMessagesInner]) -> str:
         """Run the LLM."""
-        headers, url, data = self._prepare_llm_request(prompt=prompt)
-
-        try:
-            response_text = await post_cortex_request(
-                url=url, headers=headers, data=data
+        messages = [
+            (
+                CompleteRequestMessagesInner(content=message)
+                if isinstance(message, str)
+                else message
             )
-
-        except Exception as e:
-            raise AgentGatewayError(
-                message=f"Failed Cortex LLM Request. See details:{str(e)}"
-            ) from e
-
-        try:
-            if _determine_runtime():
-                response_text = json.loads(response_text).get("content")
-
-            snowflake_response = self._parse_snowflake_response(response_text)
-
-            return snowflake_response
-        except Exception:
-            raise AgentGatewayError(
-                message=f"Failed Cortex LLM Request. Unable to parse response. See details:{response_text}"
-            )
-
-    def _prepare_llm_request(self, prompt):
-        eb = CortexEndpointBuilder(self.session)
-        url = eb.get_complete_endpoint()
-        headers = eb.get_complete_headers()
-        data = {"model": self.llm, "messages": [{"content": prompt}]}
-
-        return headers, url, data
-
-    def _parse_snowflake_response(self, data_str):
-        try:
-            json_list = []
-
-            if _determine_runtime():
-                json_list = [i["data"] for i in json.loads(data_str)]
-
-            else:
-                json_objects = data_str.split("\ndata: ")
-
-                # Iterate over each object
-                for obj in json_objects:
-                    obj = obj.strip()
-                    if obj:
-                        # Remove the 'data: ' prefix if it exists
-                        if obj.startswith("data: "):
-                            obj = obj[6:]
-                        # Load the JSON object into a Python dictionary
-                        json_dict = json.loads(str(obj))
-                        # Append the JSON dictionary to the list
-                        json_list.append(json_dict)
-
-            completion = ""
-            choices = {}
-            for chunk in json_list:
-                choices = chunk["choices"][0]
-
-                if "content" in choices["delta"].keys():
-                    completion += choices["delta"]["content"]
-
-            return completion
-        except KeyError as e:
-            raise AgentGatewayError(
-                message=f"Missing Cortex LLM response components. {str(e)}"
-            )
+            for message in messages
+        ]
+        req = CompleteRequest(model=self.llm, messages=messages)
+        res = Root(self.session.connection).cortex_inference_service.complete(req)
+        return "".join(
+            [
+                json.loads(e.data)["choices"][0]["delta"].get("content")
+                for e in res.events()
+                if json.loads(e.data)["choices"][0]["delta"].get("content")
+            ]
+        )
 
 
 class SummarizationAgent(Tool):
@@ -333,7 +285,7 @@ class Agent:
             # "---\n"
         )
 
-        response = await self.agent.arun(prompt)
+        response = await self.agent.arun([prompt])
         raw_answer = cast(str, response)
         gateway_logger.log("DEBUG", "Question: \n", input_query, block=True)
         gateway_logger.log("DEBUG", "Raw Answer: \n", raw_answer, block=True)

--- a/agent_gateway/gateway/gateway.py
+++ b/agent_gateway/gateway/gateway.py
@@ -34,8 +34,8 @@ from agent_gateway.tools.snowflake_prompts import (
 from agent_gateway.tools.utils import (
     CortexEndpointBuilder,
     _determine_runtime,
-    post_cortex_request,
     get_tag,
+    post_cortex_request,
 )
 
 

--- a/agent_gateway/gateway/gateway.py
+++ b/agent_gateway/gateway/gateway.py
@@ -495,6 +495,8 @@ class Agent:
             )
             if not is_replan:
                 break
+            else:
+                gateway_logger.log("INFO", "Replanning...")
 
             # Collect contexts for the subsequent replanner
             context = self._generate_context_for_replanner(

--- a/agent_gateway/gateway/planner.py
+++ b/agent_gateway/gateway/planner.py
@@ -21,6 +21,12 @@ import re
 from collections.abc import Sequence
 from typing import Any, Optional, Union
 
+from snowflake.core import Root
+from snowflake.core.cortex.inference_service import (
+    CompleteRequest,
+    CompleteRequestMessagesInner,
+)
+
 from agent_gateway.gateway.constants import END_OF_PLAN
 from agent_gateway.gateway.output_parser import (
     ACTION_PATTERN,
@@ -32,11 +38,6 @@ from agent_gateway.gateway.task_processor import Task
 from agent_gateway.tools.base import StructuredTool, Tool
 from agent_gateway.tools.logger import gateway_logger
 from agent_gateway.tools.schema import Plan
-from agent_gateway.tools.utils import (
-    CortexEndpointBuilder,
-    _determine_runtime,
-    post_cortex_request,
-)
 
 
 class AgentGatewayError(Exception):
@@ -209,63 +210,24 @@ class Planner:
             system_prompt = self.system_prompt
             human_prompt = f"Question: {inputs['input']}"
 
-        message = system_prompt + "\n\n" + human_prompt
-        headers, url, data = self._prepare_llm_request(prompt=message)
-        response_text = await post_cortex_request(url=url, headers=headers, data=data)
-
-        try:
-            if _determine_runtime():
-                response_text = json.loads(response_text).get("content")
-
-            snowflake_response = self._parse_snowflake_response(response_text)
-
-            return snowflake_response
-
-        except Exception:
-            raise AgentGatewayError(
-                message=f"Failed Cortex LLM Request. Unable to parse response. See details:{response_text}"
+        messages = [system_prompt + "\n\n" + human_prompt]
+        messages = [
+            (
+                CompleteRequestMessagesInner(content=message)
+                if isinstance(message, str)
+                else message
             )
-
-    def _prepare_llm_request(self, prompt):
-        eb = CortexEndpointBuilder(self.session)
-        url = eb.get_complete_endpoint()
-        headers = eb.get_complete_headers()
-        data = {"model": self.llm, "messages": [{"content": prompt}]}
-
-        return headers, url, data
-
-    def _parse_snowflake_response(self, data_str):
-        json_list = []
-
-        if _determine_runtime():
-            json_list = [i["data"] for i in json.loads(data_str)]
-
-        else:
-            json_objects = data_str.split("\ndata: ")
-
-            # Iterate over each object
-            for obj in json_objects:
-                obj = obj.strip()
-                if obj:
-                    # Remove the 'data: ' prefix if it exists
-                    if obj.startswith("data: "):
-                        obj = obj[6:]
-                    # Load the JSON object into a Python dictionary
-                    json_dict = json.loads(str(obj))
-                    # Append the JSON dictionary to the list
-                    json_list.append(json_dict)
-
-        completion = ""
-        choices = {}
-
-        for chunk in json_list:
-            choices = chunk["choices"][0]
-
-            if "content" in choices["delta"].keys():
-                completion += choices["delta"]["content"]
-
-        gateway_logger.log("DEBUG", f"LLM Generated Plan:\n{completion}")
-        return completion
+            for message in messages
+        ]
+        req = CompleteRequest(model=self.llm, messages=messages)
+        res = Root(self.session.connection).cortex_inference_service.complete(req)
+        return "".join(
+            [
+                json.loads(e.data)["choices"][0]["delta"].get("content")
+                for e in res.events()
+                if json.loads(e.data)["choices"][0]["delta"].get("content")
+            ]
+        )
 
     async def plan(self, inputs: dict, is_replan: bool, **kwargs: Any):
         llm_response = await self.run_llm(

--- a/agent_gateway/gateway/planner.py
+++ b/agent_gateway/gateway/planner.py
@@ -235,6 +235,7 @@ class Planner:
             is_replan=is_replan,
         )
         llm_response = llm_response + "\n"
+        gateway_logger.log("DEBUG", f"Agent Execution Plan:{llm_response}")
         plan_response = self.output_parser.parse(llm_response)
         return plan_response
 

--- a/agent_gateway/tools/utils.py
+++ b/agent_gateway/tools/utils.py
@@ -251,7 +251,7 @@ def get_tag(component: str) -> str:
     query_tag = {
         "origin": "sf_sit",
         "name": "orchestration-framework",
-        "version": {"major": 0, "minor": 1},
+        "version": {"major": 1, "minor": 0},
         "attributes": {"component": component},
     }
     return json.dumps(query_tag)

--- a/agent_gateway/tools/utils.py
+++ b/agent_gateway/tools/utils.py
@@ -86,21 +86,11 @@ class CortexEndpointBuilder:
             return URL_SUFFIX
         return f"{self.BASE_URL}{URL_SUFFIX}"
 
-    def get_search_endpoint(self, database, schema, service_name):
-        URL_SUFFIX = f"/api/v2/databases/{database}/schemas/{schema}/cortex-search-services/{service_name}:query"
-        URL_SUFFIX = URL_SUFFIX.lower()
-        if self.inside_snowflake:
-            return URL_SUFFIX
-        return f"{self.BASE_URL}{URL_SUFFIX}"
-
     def get_complete_headers(self) -> Headers:
         return self.BASE_HEADERS | {"Accept": "application/json"}
 
     def get_analyst_headers(self) -> Headers:
         return self.BASE_HEADERS
-
-    def get_search_headers(self) -> Headers:
-        return self.BASE_HEADERS | {"Accept": "application/json"}
 
 
 async def post_cortex_request(url: str, headers: Headers, data: dict):

--- a/agent_gateway/tools/utils.py
+++ b/agent_gateway/tools/utils.py
@@ -74,20 +74,11 @@ class CortexEndpointBuilder:
             "Authorization": f'Snowflake Token="{token}"',
         }
 
-    def get_complete_endpoint(self):
-        URL_SUFFIX = "/api/v2/cortex/inference:complete"
-        if self.inside_snowflake:
-            return URL_SUFFIX
-        return f"{self.BASE_URL}{URL_SUFFIX}"
-
     def get_analyst_endpoint(self):
         URL_SUFFIX = "/api/v2/cortex/analyst/message"
         if self.inside_snowflake:
             return URL_SUFFIX
         return f"{self.BASE_URL}{URL_SUFFIX}"
-
-    def get_complete_headers(self) -> Headers:
-        return self.BASE_HEADERS | {"Accept": "application/json"}
 
     def get_analyst_headers(self) -> Headers:
         return self.BASE_HEADERS

--- a/demo_app/demo_app.py
+++ b/demo_app/demo_app.py
@@ -20,17 +20,15 @@ import sys
 import threading
 import uuid
 import warnings
+
 import requests
-
-from agent_gateway.tools.utils import _determine_runtime
-
 import streamlit as st
 from dotenv import load_dotenv
 from snowflake.snowpark import Session
 
 from agent_gateway import Agent
 from agent_gateway.tools import CortexAnalystTool, CortexSearchTool, PythonTool
-from agent_gateway.tools.utils import parse_log_message
+from agent_gateway.tools.utils import _determine_runtime, parse_log_message
 
 warnings.filterwarnings("ignore")
 load_dotenv()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orchestration-framework"
-version = "0.1.2"
+version = "1.0.0"
 requires-python = ">=3.9"
 description = "A multi-agent framework with native support for Snowflake services"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "asyncio>=3.4.3",
     "aiohttp>=3.10.9,<4.0",
     "pydantic>=2.9.2,<3.0",
+    "snowflake>=1.1.0",
 ]
 
 [project.urls]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,18 +41,6 @@ def test_complete_url(session):
     assert "_" not in urlparse(url).hostname
 
 
-def test_search_url(session):
-    eb = CortexEndpointBuilder(session)
-    url = eb.get_search_endpoint(
-        database="TEST_DB", schema="TEST_SCHEMA", service_name="TEST_SERVICE"
-    )
-    assert url.startswith("https://")
-    assert url.endswith(
-        "/api/v2/databases/test_db/schemas/test_schema/cortex-search-services/test_service:query"
-    )
-    assert "_" not in urlparse(url).hostname
-
-
 def test_analyst_url(session):
     eb = CortexEndpointBuilder(session)
     url = eb.get_analyst_endpoint()
@@ -74,11 +62,3 @@ def test_analyst_headers(session):
     headers = eb.get_analyst_headers()
     assert headers["Content-Type"] == "application/json"
     assert headers["Authorization"] == 'Snowflake Token="dummy_token"'
-
-
-def test_search_headers(session):
-    eb = CortexEndpointBuilder(session)
-    headers = eb.get_search_headers()
-    assert headers["Content-Type"] == "application/json"
-    assert headers["Authorization"] == 'Snowflake Token="dummy_token"'
-    assert headers["Accept"] == "application/json"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,28 +33,12 @@ def session():
     return MockConnection(host="example_host", token="dummy_token")
 
 
-def test_complete_url(session):
-    eb = CortexEndpointBuilder(session)
-    url = eb.get_complete_endpoint()
-    assert url.startswith("https://")
-    assert url.endswith("/api/v2/cortex/inference:complete")
-    assert "_" not in urlparse(url).hostname
-
-
 def test_analyst_url(session):
     eb = CortexEndpointBuilder(session)
     url = eb.get_analyst_endpoint()
     assert url.startswith("https://")
     assert url.endswith("/api/v2/cortex/analyst/message")
     assert "_" not in urlparse(url).hostname
-
-
-def test_complete_headers(session):
-    eb = CortexEndpointBuilder(session)
-    headers = eb.get_complete_headers()
-    assert headers["Content-Type"] == "application/json"
-    assert headers["Authorization"] == 'Snowflake Token="dummy_token"'
-    assert headers["Accept"] == "application/json"
 
 
 def test_analyst_headers(session):

--- a/uv.lock
+++ b/uv.lock
@@ -187,6 +187,15 @@ wheels = [
 ]
 
 [[package]]
+name = "atpublic"
+version = "5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/af/d5113daf3947044e43d74305cbd31502915c784e158c0c098db03ceeff17/atpublic-5.1.tar.gz", hash = "sha256:abc1f4b3dbdd841cc3539e4b5e4f3ad41d658359de704e30cb36da4d4e9d3022", size = 14670 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/c1/6408177d6078e159fd3a2a53206e8d1d51ba30ef75ad016b19dada6952b4/atpublic-5.1-py3-none-any.whl", hash = "sha256:135783dbd887fbddb6ef032d104da70c124f2b44b9e2d79df07b9da5334825e3", size = 5209 },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1011,12 +1020,13 @@ wheels = [
 
 [[package]]
 name = "orchestration-framework"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "asyncio" },
     { name = "pydantic" },
+    { name = "snowflake" },
     { name = "snowflake-snowpark-python", extra = ["pandas"] },
 ]
 
@@ -1044,6 +1054,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3,<9.0" },
     { name = "python-dotenv", marker = "extra == 'streamlit'", specifier = ">=1.0.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.9,<1.0" },
+    { name = "snowflake", specifier = ">=1.1.0" },
     { name = "snowflake-snowpark-python", extras = ["pandas"], specifier = ">=1.22.1,<2.0" },
     { name = "streamlit", marker = "extra == 'streamlit'", specifier = ">=1.39.0,<2.0" },
 ]
@@ -1901,6 +1912,19 @@ wheels = [
 ]
 
 [[package]]
+name = "snowflake"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "snowflake-core" },
+    { name = "snowflake-legacy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/f5/b0c888bea68bcad34fc4a3ac2c9bde0d621b4227294603063b3f0efd96e3/snowflake-1.1.0.tar.gz", hash = "sha256:5d02caf6ab0f94e22145e2b1125936d15343fbf691b37dbc4cac6524c93cd343", size = 6040 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/16/354ab80165e06e63ef4906c939424ad6cf8dc5076238ada6f29ff2fc928c/snowflake-1.1.0-py3-none-any.whl", hash = "sha256:4b0c03a36b1ed28ffaeb3b433ba057dd8c25ec6e444b35f8ad66388e9c98fe30", size = 5634 },
+]
+
+[[package]]
 name = "snowflake-connector-python"
 version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1951,6 +1975,33 @@ wheels = [
 pandas = [
     { name = "pandas" },
     { name = "pyarrow" },
+]
+
+[[package]]
+name = "snowflake-core"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "atpublic" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "snowflake-connector-python" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f1/e6fbfae6afdd576b799208c70126aa445469e00bb987e7514bc647334397/snowflake_core-1.1.0.tar.gz", hash = "sha256:620a0e4026185f39e025a3db9ec6240d8f91b14d737891ea9de3f681224471ed", size = 1296050 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/89/14015a5efbc43386550c1b32a3311c638d9cd86e6dff1f5d63ed382b874f/snowflake_core-1.1.0-py3-none-any.whl", hash = "sha256:a17e2c92ce701d42ec81a60a474fceca08ded36bf59ec14acfa423a87d6098df", size = 1926393 },
+]
+
+[[package]]
+name = "snowflake-legacy"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/41/a6211bd2109913eee1506d37865ab13cf9a8cc2faa41833da3d1ffec654b/snowflake_legacy-1.0.0.tar.gz", hash = "sha256:2044661c79ba01841ab279c5e74b994532244c9d103224eba16eb159c8ed6033", size = 4043 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/8c/64f9b5ee0c3f376a733584c480b31addbf2baff7bb41f655e5e3f3719d3b/snowflake_legacy-1.0.0-py3-none-any.whl", hash = "sha256:25f9678f180d7d5f5b60d17f8112f0ee8a7a77b82c67fd599ed6e27bd502be5a", size = 3059 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Pull Request Overview

This PR switches the search and LLM completion functionality over to the Snowflake core API, replacing legacy helper functions with direct API calls.  
- Updated agent_gateway/tools/snowflake_tools.py to use the new core search API via Root.  
- Reworked LLM request handling in agent_gateway/gateway/planner.py and agent_gateway/gateway/gateway.py to build complete requests using the core inference service.  
- Adjusted tests in tests/test_utils.py and cleanup in agent_gateway/tools/utils.py to remove obsolete endpoint and header helpers.

### Reviewed Changes

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| pyproject.toml | Added dependency on snowflake v1.1.0 to support the core API. |
| agent_gateway/tools/snowflake_tools.py | Updated search functionality to use core API calls and removed legacy request preparation. |
| tests/test_utils.py | Removed tests for deprecated endpoint and header functions. |
| agent_gateway/gateway/planner.py | Replaced legacy LLM request handling with a core API-based complete request. |
| agent_gateway/tools/utils.py | Removed unused endpoint and header helper functions. |
| demo_app/demo_app.py | Adjusted import ordering to match dependency changes. |
| agent_gateway/gateway/gateway.py | Updated LLM completion interface and refactored method signatures to use core API calls. |
</details>