### PR TITLE
feat: prevent token overload with max_results param for Cortex Analyst tool

### DIFF
--- a/agent_gateway/tools/snowflake_tools.py
+++ b/agent_gateway/tools/snowflake_tools.py
@@ -191,6 +191,7 @@ class CortexAnalystTool(Tool):
         service_topic: str,
         data_description: str,
         snowflake_connection: Union[Session, SnowflakeConnection],
+        max_results: int = None,
     ):
         """Initialize CortexAnalystTool with parameters."""
         tname = semantic_model.replace(".yaml", "") + "_" + "cortexanalyst"
@@ -207,10 +208,16 @@ class CortexAnalystTool(Tool):
         )
         self.FILE = semantic_model
         self.STAGE = stage
+        self.max_results = max_results
 
         gateway_logger.log("INFO", "Cortex Analyst Tool successfully initialized")
 
     def __call__(self, prompt: str) -> Any:
+        if self.max_results is not None:
+            prompt = (
+                prompt
+                + f" Only return up to {self.max_results} relevant records in the final results. "
+            )
         return self.asearch(query=prompt)
 
     async def asearch(self, query: str) -> Dict[str, Any]:

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -81,6 +81,31 @@ def test_analyst_tool(session, question, answer):
     assert response == answer
 
 
+@pytest.mark.parametrize(
+    "question, answer",
+    [
+        pytest.param(
+            "What are the top companies by market cap?",
+            "{'SHORTNAME': ['Microsoft Corporation', 'Apple Inc.', 'NVIDIA Corporation', 'Alphabet Inc.', 'Amazon.com, Inc.'], 'MARKETCAP': [3150184448000, 3019131060224, 2973639376896, 2164350779392, 1917936336896]}",
+            id="top_market_cap",
+        ),
+    ],
+)
+def test_analyst_w_max_results(session, question, answer):
+    analyst_config = {
+        "semantic_model": "sp500_semantic_model.yaml",
+        "stage": "ANALYST",
+        "service_topic": "S&P500 company and stock metrics",
+        "data_description": "a table with stock and financial metrics about S&P500 companies ",
+        "snowflake_connection": session,
+        "max_results": 5,
+    }
+    sp500 = CortexAnalystTool(**analyst_config)
+    response = asyncio.run(sp500(question)).get("output")
+
+    assert response == answer
+
+
 def test_python_tool():
     def get_news(_) -> dict:
         with open("tests/data/response.json") as f:


### PR DESCRIPTION
max_results: truncates output of cortex analyst tool to prevent token overload on agent